### PR TITLE
Added ptz_parse_sections function

### DIFF
--- a/build/functions.php
+++ b/build/functions.php
@@ -118,3 +118,20 @@ function partage_tanzania_scripts() {
   wp_enqueue_style( 'partage-tanzania-style', get_stylesheet_uri() );
 }
 add_action( 'wp_enqueue_scripts', 'partage_tanzania_scripts' );
+
+function ptz_parse_sections( $content ) {
+	if (is_singular()) {
+		$string = $content;
+		$pattern = '#<hr[^>]*>#';
+		$num_seperators = preg_match_all( $pattern, $string );
+
+		for ($i=1; $i <= $num_seperators; $i++) {
+			$classes = 'page-section ' . $GLOBALS['post']->post_name . '-section' . ($i + 1);
+			$replacement = '</section><section class="' . $classes . '">';
+			$content = preg_replace( $pattern, $replacement, $string, 1 );
+			$string = $content;
+		}
+	}
+	return $content;
+}
+add_filter( 'the_content', 'ptz_parse_sections' );

--- a/build/template-parts/content-page.php
+++ b/build/template-parts/content-page.php
@@ -15,9 +15,11 @@
   </header><!-- .entry-header -->
 
   <div class="entry-content">
-    <?php
-    the_content();
-    ?>
+    <section class="page-section <?php echo get_post_field( 'post_name' ); ?>-section1">
+      <?php
+      the_content();
+      ?>
+    </section>
   </div><!-- .entry-content -->
 
 </article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
The ptz-parse-sections function searches and replaces horizontal rules
(i.e. <hr> tags) in page content with section breaks. Each section has
a general 'page-section' class as well as a 'slug-section$' class where
slug is the current page's slug and $ is the number of the section
starting at 1.